### PR TITLE
BUG FIX : Included `cstdint` for integer types inference and recognition.

### DIFF
--- a/src/integer_type_detection.cpp
+++ b/src/integer_type_detection.cpp
@@ -8,6 +8,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 
@@ -16,17 +17,17 @@ using namespace panda;
 namespace
 {
    /// Returns the integer type interpreted from char*.
-   IntegerType integerTypeFromString(char*);
+   IntegerType integerTypeFromString(char *);
 }
 
-IntegerType panda::integerType(int argc, char** argv)
+IntegerType panda::integerType(int argc, char **argv)
 {
-   assert( argc > 0 && argv != nullptr );
-   for ( int i = 1; i < argc; ++i )
+   assert(argc > 0 && argv != nullptr);
+   for (int i = 1; i < argc; ++i)
    {
-      if ( std::strcmp(argv[i], "-i") == 0 )
+      if (std::strcmp(argv[i], "-i") == 0)
       {
-         if ( i + 1 == argc )
+         if (i + 1 == argc)
          {
             std::string message = "Command line option -i needs a parameter:";
             message += " Choose either \"16\", \"32\", \"64\", \"safe\" or \"inf\"-";
@@ -34,15 +35,15 @@ IntegerType panda::integerType(int argc, char** argv)
          }
          return integerTypeFromString(argv[i + 1]);
       }
-      else if ( std::strncmp(argv[i], "-i=", 3) == 0 )
+      else if (std::strncmp(argv[i], "-i=", 3) == 0)
       {
          return integerTypeFromString(argv[i] + 3);
       }
-      else if ( std::strncmp(argv[i], "--integer-type=", 15) == 0 )
+      else if (std::strncmp(argv[i], "--integer-type=", 15) == 0)
       {
          return integerTypeFromString(argv[i] + 15);
       }
-      else if ( std::strncmp(argv[i], "-i", 2) == 0 || std::strncmp(argv[i], "--i", 3) == 0 )
+      else if (std::strncmp(argv[i], "-i", 2) == 0 || std::strncmp(argv[i], "--i", 3) == 0)
       {
          throw std::invalid_argument("Illegal parameter. Did you mean \"-i <type>\" or \"--integer-type=<type>\"?");
       }
@@ -52,37 +53,37 @@ IntegerType panda::integerType(int argc, char** argv)
 
 namespace
 {
-   IntegerType integerTypeFromString(char* string)
+   IntegerType integerTypeFromString(char *string)
    {
-      if ( std::strcmp(string, "16") == 0 )
+      if (std::strcmp(string, "16") == 0)
       {
-         #ifdef INT16_MIN
+#ifdef INT16_MIN
          return IntegerType::Fixed16;
-         #else
+#else
          throw std::invalid_argument("Your system does not support an integer type with exactly 16 bit width.");
-         #endif
+#endif
       }
-      else if ( std::strcmp(string, "32") == 0 )
+      else if (std::strcmp(string, "32") == 0)
       {
-         #ifdef INT32_MIN
+#ifdef INT32_MIN
          return IntegerType::Fixed32;
-         #else
+#else
          throw std::invalid_argument("Your system does not support an integer type with exactly 32 bit width.");
-         #endif
+#endif
       }
-      else if ( std::strcmp(string, "64") == 0 )
+      else if (std::strcmp(string, "64") == 0)
       {
-         #ifdef INT64_MIN
+#ifdef INT64_MIN
          return IntegerType::Fixed64;
-         #else
+#else
          throw std::invalid_argument("Your system does not support an integer type with exactly 64 bit width.");
-         #endif
+#endif
       }
-      else if ( std::strcmp(string, "safe") == 0 )
+      else if (std::strcmp(string, "safe") == 0)
       {
          return IntegerType::Safe;
       }
-      else if ( std::strcmp(string, "inf") == 0 )
+      else if (std::strcmp(string, "inf") == 0)
       {
          return IntegerType::Variable;
       }
@@ -91,4 +92,3 @@ namespace
       throw std::invalid_argument(message);
    }
 }
-


### PR DESCRIPTION
## TL;DR
Implicit import of `stdint`/`cstdint` for integer macros breaks in modern versions of C++ and fails unit tests.
Explicitly stating `#include <cstdint>` in `src/integer_type_detection.cpp` fixes this issue.


## Extended

### Issue
`src/integer_type_detection.cpp` uses the macros `INT16_MIN`, `INT32_MIN`, and `INT64_MIN` to detect fixed-width integer support, but it never includes `<cstdint>`/`<stdint.h>`. On modern toolchains these macros aren’t visible unless the correct header is included, causing the test `src/test/integer_type_detection.cpp` to fail when running `make`, throwing :
```Your system does not support an integer type with exactly 16 bit width.```

### Expected behavior
Compiles, passes tests, and runs.

### Changes
Edited `src/integer_type_detection.cpp` to explicitly include `<cstdint>`. 
Behavior is fixed, compilation succeeds, and executable runs as expected.

_Minor formatting was also edited automatically. Main change is on lines 10~11._

### Tested configuration

- **OS** : Ubuntu 24.04.3 LTS
- **Processor** : Intel Core Ultra 7 155H x22
- **Compiler wrapper** : Intel(R) oneAPI DPC++/C++ Compiler 2025.0.4 (2025.0.4.20241205)
- **g++** : g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0